### PR TITLE
Update comment colors in dark theme

### DIFF
--- a/src/dark.json
+++ b/src/dark.json
@@ -136,10 +136,10 @@
       "color": "#79B8FF"
     },
     "comment": {
-      "color": "#AAAAAA"
+      "color": "#69717A"
     },
     "comment.doc": {
-      "color": "#AAAAAA"
+      "color": "#69717A"
     },
     "constant": {
       "color": "#79B8FF"

--- a/themes/min-theme.json
+++ b/themes/min-theme.json
@@ -144,10 +144,10 @@
             "color": "#79B8FF"
           },
           "comment": {
-            "color": "#AAAAAA"
+            "color": "#69717A"
           },
           "comment.doc": {
-            "color": "#AAAAAA"
+            "color": "#69717A"
           },
           "constant": {
             "color": "#79B8FF"
@@ -355,10 +355,10 @@
             "color": "#79B8FF"
           },
           "comment": {
-            "color": "#AAAAAA"
+            "color": "#69717A"
           },
           "comment.doc": {
-            "color": "#AAAAAA"
+            "color": "#69717A"
           },
           "constant": {
             "color": "#79B8FF"


### PR DESCRIPTION
Previously, comments in the theme were too similar in color to the code, making them difficult to distinguish. This update improves readability by adjusting the comment color to provide better contrast.

![comment](https://github.com/user-attachments/assets/a9024c9b-f776-480c-b1f0-3eaaf38f5d9d)
