### PR TITLE
fix: update colors for error and warning backgrounds and borders

### DIFF
--- a/themes/min-theme.json
+++ b/themes/min-theme.json
@@ -59,12 +59,15 @@
         "terminal.ansi.dim_white": "#898989",
         "link_text.hover": "#BBBBBB",
         "created": "#6C9C77",
-        "deleted": "#f97583",
-        "deleted.background": "#f9758330",
+        "deleted": "#F97583",
+        "deleted.background": "#F9758330",
         "info.background": "#6C9C7730",
-        "error": "#f97583",
-        "error.background": "#1A1A1A",
-        "error.border": "#f97583",
+        "error": "#F97583",
+        "error.background": "#47181C",
+        "error.border": "#F97583",
+        "warning": "#FFE62A",
+        "warning.background": "#55450E",
+        "warning.border": "#FFE62A",
         "hidden": "#727272",
         "hint": "#969696ff",
         "ignored": "#99999980",
@@ -106,7 +109,7 @@
             "color": "#BBB"
           },
           "punctuation": {
-            "color": "#d1d1d1"
+            "color": "#D1D1D1"
           },
           "string": {
             "color": "#FFAB70"
@@ -122,7 +125,7 @@
             "font_weight": 400
           },
           "text.literal": {
-            "color": "#e394dc",
+            "color": "#E394DC",
             "font_style": "normal",
             "font_weight": 400
           },
@@ -205,12 +208,15 @@
         "terminal.ansi.dim_white": "#898989",
         "link_text.hover": "#BBBBBB",
         "created": "#6C9C77",
-        "deleted": "#f97583",
-        "deleted.background": "#f9758330",
+        "deleted": "#F97583",
+        "deleted.background": "#F9758330",
         "info.background": "#6C9C7730",
-        "error": "#f97583",
-        "error.background": "#1A1A1A",
-        "error.border": "#f97583",
+        "error": "#F97583",
+        "error.background": "#47181C",
+        "error.border": "#F97583",
+        "warning": "#FFE62A",
+        "warning.background": "#55450E",
+        "warning.border": "#FFE62A",
         "hidden": "#727272",
         "hint": "#969696ff",
         "ignored": "#99999980",
@@ -252,7 +258,7 @@
             "color": "#BBB"
           },
           "punctuation": {
-            "color": "#d1d1d1"
+            "color": "#D1D1D1"
           },
           "string": {
             "color": "#FFAB70"
@@ -268,7 +274,7 @@
             "font_weight": 400
           },
           "text.literal": {
-            "color": "#e394dc",
+            "color": "#E394DC",
             "font_style": "normal",
             "font_weight": 400
           },
@@ -348,17 +354,20 @@
         "terminal.ansi.cyan": "#0097A7",
         "terminal.ansi.bright_cyan": "#4DD0E1",
         "terminal.ansi.dim_cyan": "#006064",
-        "terminal.ansi.white": "#b1b1b1",
-        "terminal.ansi.bright_white": "#b1b1b1",
+        "terminal.ansi.white": "#B1B1B1",
+        "terminal.ansi.bright_white": "#B1B1B1",
         "terminal.ansi.dim_white": "#F5F5F5",
         "link_text.hover": "#212121",
         "created": "#388E3C",
         "deleted": "#D32F2F",
-        "deleted.background": "#f9758330",
+        "deleted.background": "#F9758330",
         "info.background": "#6C9C7730",
         "error": "#D32F2F",
         "error.background": "#FFEBEE",
         "error.border": "#D32F2F",
+        "warning": "#FFE62A",
+        "warning.background": "#FFFDE7",
+        "warning.border": "#FFE62A",
         "hidden": "#BDBDBD",
         "hint": "#757575",
         "ignored": "#75757580",
@@ -494,17 +503,20 @@
         "terminal.ansi.cyan": "#0097A7",
         "terminal.ansi.bright_cyan": "#4DD0E1",
         "terminal.ansi.dim_cyan": "#006064",
-        "terminal.ansi.white": "#b1b1b1",
-        "terminal.ansi.bright_white": "#b1b1b1",
+        "terminal.ansi.white": "#B1B1B1",
+        "terminal.ansi.bright_white": "#B1B1B1",
         "terminal.ansi.dim_white": "#F5F5F5",
         "link_text.hover": "#212121",
         "created": "#388E3C",
         "deleted": "#D32F2F",
-        "deleted.background": "#f9758330",
+        "deleted.background": "#F9758330",
         "info.background": "#6C9C7730",
         "error": "#D32F2F",
         "error.background": "#FFEBEE",
         "error.border": "#D32F2F",
+        "warning": "#FFE62A",
+        "warning.background": "#FFFDE7",
+        "warning.border": "#FFE62A",
         "hidden": "#BDBDBD",
         "hint": "#757575",
         "ignored": "#75757580",


### PR DESCRIPTION
Updated the hover dialog colors for errors and warnings, making them easier to read. Also capitalized all the letters of hex values inside the theme.json for consistency.

# Before

<img width="790" height="363" alt="Screenshot 2025-10-28 at 22 25 28" src="https://github.com/user-attachments/assets/413aba45-bd4b-484c-9219-8b881d62940f" />
<img width="790" height="363" alt="Screenshot 2025-10-28 at 22 25 35" src="https://github.com/user-attachments/assets/8243808a-09c7-4ae2-ae46-079bd2fef241" />
<img width="790" height="363" alt="Screenshot 2025-10-28 at 22 26 46" src="https://github.com/user-attachments/assets/22630449-8f96-4045-b22a-093d756e2c51" />

# After

<img width="790" height="363" alt="Screenshot 2025-10-28 at 22 26 01" src="https://github.com/user-attachments/assets/168759d7-568c-4c58-b446-1912c15e5edf" />
<img width="790" height="363" alt="Screenshot 2025-10-28 at 22 26 05" src="https://github.com/user-attachments/assets/7142fb49-3aad-42d1-a7cd-3196cf8bcc15" />
<img width="790" height="363" alt="Screenshot 2025-10-28 at 22 27 07" src="https://github.com/user-attachments/assets/ae43719b-1fc1-4b2b-bfaf-77d1518196d5" />